### PR TITLE
Bug: profile not updating on login

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,7 +12,7 @@ import ProfileDetails from './pages/ProfileDetails';
 
 import { AuthProvider } from "./contexts/user";
 import PrivateRoute from "./components/PrivateRoute/";
-import { ProfileProvider } from "./contexts/profile";
+import ProfileProvider from "./contexts/profile";
 import BecomeASitter from "./pages/BecomeASitter";
 
 function App() {

--- a/client/src/contexts/profile.js
+++ b/client/src/contexts/profile.js
@@ -1,4 +1,5 @@
 import React, {useContext, createContext } from 'react';
+import { withRouter } from 'react-router-dom';
 
 export const ProfileContext = createContext(null);
 
@@ -7,7 +8,7 @@ export const useProfileContext = () => {
     return profileContext;
 }
 
-export class ProfileProvider extends React.Component {
+class ProfileProvider extends React.Component {
     constructor(props) {
         super(props)
         this.state = {
@@ -22,9 +23,21 @@ export class ProfileProvider extends React.Component {
             })
         })
     }
+    componentDidUpdate(prevProps) {
+        const hasLoggedIn = (prevProps.location.pathname === "/login" || prevProps.location.pathname === "/signup") && (this.props.location.pathname !== "/login" || this.props.location.pathname !== "/signup")
+        if (hasLoggedIn) {
+            fetch("/profile/me").then((profile) => {
+              profile.json().then((result) => {
+                this.state.setProfile(result);
+              });
+            });
+        }
+    }
     render() {
         return (
             <ProfileContext.Provider value={this.state}>{this.props.children}</ProfileContext.Provider>
         )
     }
 }
+
+export default withRouter(ProfileProvider);


### PR DESCRIPTION
**What it does**
- Fix a bug where the profile provider was not updating the active profile on login
- Anytime a user navigates from "/login" or "/signup" to another page (not "/login" or "/signup") the profile provider fetches the profile again

I think I missed this in my initial Profile Context feature because I was testing it while leaving the same profile logged in. This is a really lean bug fix but the bug would be visible in presentation so I've thoroughly tested it and merged it into the presentation branch.