### PR TITLE
Fix notification integration

### DIFF
--- a/client/src/contexts/socket.js
+++ b/client/src/contexts/socket.js
@@ -1,9 +1,8 @@
 import React, { Fragment, useRef } from 'react';
-import socketClient from "socket.io-client";
 import { useProfileContext } from './profile';
+import { socket } from "../services/socket";
 
 function SocketHandler({children}) {
-    const socket = socketClient(window.location.origin + "/")
     const {profile, setProfile} = useProfileContext()
     const oldProfile = useRef(profile)
     if (profile && (!oldProfile.current || oldProfile.current._id !== profile._id)) {

--- a/client/src/services/socket.js
+++ b/client/src/services/socket.js
@@ -1,0 +1,2 @@
+import socketClient from "socket.io-client";
+export const socket = socketClient(window.location.origin + "/");

--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,6 @@ const express = require("express");
 const { join } = require("path");
 const cookieParser = require("cookie-parser");
 const logger = require("morgan");
-const socketIO = require("socket.io");
 
 require("dotenv").config();
 


### PR DESCRIPTION
**What it does:**

- Fixes the lockout on the client when using sockets
- The problem I think was the socket was being created inside the socket context component which probably created another connection on updates. So I just declared it outside the component and make sure its available once throughout the app.

**What to watch out for:**

- The _WebSocket connection to 'ws://localhost:3000/socket.io/?EIO=3&transport=websocket&sid=_m7dvENwRw9zjBm8AAAC' failed: Connection closed before receiving a handshake response_ error still persists but only happens once during an application now. I think its React Dev server that is displaying this, but in production mode it shouldnt show it.
- There is a React update error that sometimes happens in Bookings.js but does not get often triggered